### PR TITLE
非同期処理(async await利用箇所)のエラーハンドリングを見直し

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Serverless CRUD Prototype",
   "scripts": {
-    "test": "mocha -t 5000 -R nyan",
+    "test": "mocha -t 8000 -R nyan",
     "lint": "tslint -c tslint.json src/**/*.ts",
     "build": "webpack",
     "build:test": "webpack --config config/tests/webpack.config.js",

--- a/src/functions/client.ts
+++ b/src/functions/client.ts
@@ -20,10 +20,12 @@ export const find = async (
   context: lambda.Context,
   callback: lambda.Callback
 ): Promise<void> => {
-  const clientId = parseInt(event.pathParameters.id);
-  const clientRepository = new ClientRepository();
+  try {
+    const clientId = parseInt(event.pathParameters.id);
+    const clientRepository = new ClientRepository();
 
-  await clientRepository.find(clientId).then((clientEntity) => {
+    const clientEntity = await clientRepository.find(clientId);
+
     const responseBody = {
       client_id: clientEntity.id,
       client_secret: clientEntity.secret,
@@ -40,11 +42,11 @@ export const find = async (
     const successResponse = new SuccessResponse(responseBody);
 
     callback(undefined, successResponse.getResponse());
-  }).catch((error: Error) => {
+  } catch (error) {
     const errorResponse = new ErrorResponse(error);
     const response = errorResponse.getResponse();
 
     callback(undefined, response);
-  });
+  }
 };
 

--- a/src/functions/resource.ts
+++ b/src/functions/resource.ts
@@ -81,7 +81,7 @@ export const create = async (
 };
 
 /**
- * リソースの取得をする
+ * リソースを取得する
  *
  * @param event
  * @param context

--- a/src/functions/resource.ts
+++ b/src/functions/resource.ts
@@ -25,39 +25,40 @@ export const create = async (
   context: lambda.Context,
   callback: lambda.Callback
 ): Promise<void> => {
+  try {
+    const environment = new Environment(event);
 
-  const environment = new Environment(event);
+    let requestBody;
+    if (environment.isLocal() === true) {
+      requestBody = event.body;
+    } else {
+      requestBody = JSON.parse(event.body);
+    }
 
-  let requestBody;
-  if (environment.isLocal() === true) {
-    requestBody = event.body;
-  } else {
-    requestBody = JSON.parse(event.body);
-  }
+    const httpMethod   = requestBody.http_method;
+    const resourcePath = requestBody.resource_path;
+    const name         = requestBody.name;
+    const scopes       = requestBody.scopes;
 
-  const httpMethod   = requestBody.http_method;
-  const resourcePath = requestBody.resource_path;
-  const name         = requestBody.name;
-  const scopes       = requestBody.scopes;
+    const nowDateTime = new Date().getTime();
+    const resourceId  = `${httpMethod}/${resourcePath}`;
 
-  const nowDateTime = new Date().getTime();
-  const resourceId  = `${httpMethod}/${resourcePath}`;
+    const resourceEntity = new ResourceEntity(resourceId, nowDateTime);
+    resourceEntity.httpMethod = httpMethod;
+    resourceEntity.resourcePath = resourcePath;
+    resourceEntity.name = name;
+    resourceEntity.scopes = scopes;
+    resourceEntity.updatedAt = nowDateTime;
 
-  const resourceEntity = new ResourceEntity(resourceId, nowDateTime);
-  resourceEntity.httpMethod = httpMethod;
-  resourceEntity.resourcePath = resourcePath;
-  resourceEntity.name = name;
-  resourceEntity.scopes = scopes;
-  resourceEntity.updatedAt = nowDateTime;
+    if (environment.isLocal() === true) {
+      dynamoDbDocumentClient = AwsSdkFactory.getInstance().createDynamoDbDocumentClient(
+        environment.isLocal()
+      );
+    }
+    const resourceRepository = new ResourceRepository(dynamoDbDocumentClient);
 
-  if (environment.isLocal() === true) {
-    dynamoDbDocumentClient = AwsSdkFactory.getInstance().createDynamoDbDocumentClient(
-      environment.isLocal()
-    );
-  }
-  const resourceRepository = new ResourceRepository(dynamoDbDocumentClient);
+    await resourceRepository.save(resourceEntity);
 
-  await resourceRepository.save(resourceEntity).then((resourceEntity: ResourceEntity) => {
     const responseBody = {
       id: resourceEntity.id,
       http_method: resourceEntity.httpMethod,
@@ -71,12 +72,12 @@ export const create = async (
     const successResponse = new SuccessResponse(responseBody, 201);
 
     callback(undefined, successResponse.getResponse());
-  }).catch((error: Error) => {
+  } catch (error) {
     const errorResponse = new ErrorResponse(error);
     const response = errorResponse.getResponse();
 
     callback(undefined, response);
-  });
+  }
 };
 
 /**

--- a/src/functions/user.ts
+++ b/src/functions/user.ts
@@ -21,7 +21,11 @@ let dynamoDbDocumentClient = AwsSdkFactory.getInstance().createDynamoDbDocumentC
  * @param context
  * @param callback
  */
-export const create = async (event: LambdaExecutionEvent, context: lambda.Context, callback: lambda.Callback): Promise<void> => {
+export const create = async (
+  event: LambdaExecutionEvent,
+  context: lambda.Context,
+  callback: lambda.Callback
+): Promise<void> => {
   // TODO このあたりの処理はリクエストオブジェクトに集約する @keita-nishimoto
   try {
     const environment = new Environment(event);
@@ -85,7 +89,11 @@ export const create = async (event: LambdaExecutionEvent, context: lambda.Contex
  * @param context
  * @param callback
  */
-export const find = async (event: LambdaExecutionEvent, context: lambda.Context, callback: lambda.Callback): Promise<void> => {
+export const find = async (
+  event: LambdaExecutionEvent,
+  context: lambda.Context,
+  callback: lambda.Callback
+): Promise<void> => {
   // TODO このあたりの処理はリクエストオブジェクトに集約する @keita-nishimoto
   try {
     const userId = event.pathParameters.id;

--- a/src/repositories/AccessTokenRepository.ts
+++ b/src/repositories/AccessTokenRepository.ts
@@ -25,40 +25,45 @@ export default class AccessTokenRepository implements AccessTokenRepositoryInter
    * @returns {Promise<AccessTokenEntity>}
    */
   async fetch(accessToken: string): Promise<AccessTokenEntity> {
-    const headers = {
-      "Content-Type": "application/json"
-    };
+    try {
+      const headers = {
+        "Content-Type": "application/json"
+      };
 
-    const requestData = {
-      token: accessToken
-    };
+      const requestData = {
+        token: accessToken
+      };
 
-    const requestConfig = {
-      headers: headers,
-      auth: {
-        username: Authlete.getApiKey(),
-        password: Authlete.getApiSecret()
+      const requestConfig = {
+        headers: headers,
+        auth: {
+          username: Authlete.getApiKey(),
+          password: Authlete.getApiSecret()
+        }
+      };
+
+      const response: AxiosResponse = await axios.post(
+        "https://api.authlete.com/api/auth/introspection",
+        requestData,
+        requestConfig
+      );
+
+      if (response.status !== 200) {
+        Logger.critical(response);
+        return Promise.reject(new InternalServerError());
       }
-    };
 
-    const response: AxiosResponse = await axios.post(
-      "https://api.authlete.com/api/auth/introspection",
-      requestData,
-      requestConfig
-    );
+      const introspectionResponse: AuthleteResponse.IntrospectionResponse = response.data;
+      const accessTokenEntity = new AccessTokenEntity(
+        accessToken
+      );
+      accessTokenEntity.introspectionResponse = introspectionResponse;
 
-    if (response.status !== 200) {
-      Logger.critical(response);
-      throw new InternalServerError();
+      return accessTokenEntity;
+    } catch (error) {
+      Logger.critical(error);
+      return Promise.reject(error);
     }
-
-    const introspectionResponse: AuthleteResponse.IntrospectionResponse = response.data;
-    const accessTokenEntity = new AccessTokenEntity(
-      accessToken
-    );
-    accessTokenEntity.introspectionResponse = introspectionResponse;
-
-    return accessTokenEntity;
   }
 
   /**
@@ -69,49 +74,60 @@ export default class AccessTokenRepository implements AccessTokenRepositoryInter
    * @returns {Promise<AccessTokenEntity>}
    */
   async issue(authorizationCode: string, redirectUri: string): Promise<AccessTokenEntity> {
-    const headers = {
-      "Content-Type": "application/json"
-    };
+    try {
+      const headers = {
+        "Content-Type": "application/json"
+      };
 
-    const requestData = {
-      parameters: `code=${authorizationCode}&grant_type=authorization_code&redirect_uri=${redirectUri}`
-    };
+      const requestData = {
+        parameters: `code=${authorizationCode}&grant_type=authorization_code&redirect_uri=${redirectUri}`
+      };
 
-    const requestConfig = {
-      headers: headers,
-      auth: {
-        username: Authlete.getApiKey(),
-        password: Authlete.getApiSecret()
+      const requestConfig = {
+        headers: headers,
+        auth: {
+          username: Authlete.getApiKey(),
+          password: Authlete.getApiSecret()
+        }
+      };
+
+      const response: AxiosResponse = await axios.post(
+        "https://api.authlete.com/api/auth/token",
+        requestData,
+        requestConfig
+      );
+
+      if (response.status !== 200) {
+        console.error(response);
+        return Promise.reject(new InternalServerError());
       }
-    };
 
-    const response: AxiosResponse = await axios.post(
-      "https://api.authlete.com/api/auth/token",
-      requestData,
-      requestConfig
-    );
+      const tokenResponse: AuthleteResponse.TokenResponse = response.data;
+      const accessTokenEntity = new AccessTokenEntity(tokenResponse.accessToken);
+      accessTokenEntity.tokenResponse = tokenResponse;
 
-    if (response.status !== 200) {
-      console.error(response);
-      throw new InternalServerError();
-    }
-
-    const tokenResponse: AuthleteResponse.TokenResponse = response.data;
-    const accessTokenEntity = new AccessTokenEntity(tokenResponse.accessToken);
-    accessTokenEntity.tokenResponse = tokenResponse;
-
-    if (accessTokenEntity.extractTokenAction() !== "OK") {
-      switch (accessTokenEntity.extractTokenAction()) {
-        case "BAD_REQUEST":
-          throw new BadRequestError(accessTokenEntity.tokenResponse.resultMessage);
-        case "FORBIDDEN":
-          throw new ForbiddenError(accessTokenEntity.tokenResponse.resultMessage);
-        default:
-          Logger.critical(accessTokenEntity.tokenResponse);
-          throw new InternalServerError(accessTokenEntity.tokenResponse.resultMessage);
+      if (accessTokenEntity.extractTokenAction() !== "OK") {
+        switch (accessTokenEntity.extractTokenAction()) {
+          case "BAD_REQUEST":
+            return Promise.reject(
+              new BadRequestError(accessTokenEntity.tokenResponse.resultMessage)
+            );
+          case "FORBIDDEN":
+            return Promise.reject(
+              new ForbiddenError(accessTokenEntity.tokenResponse.resultMessage)
+            );
+          default:
+            Logger.critical(accessTokenEntity.tokenResponse);
+            return Promise.reject(
+              new InternalServerError(accessTokenEntity.tokenResponse.resultMessage)
+            );
+        }
       }
-    }
 
-    return accessTokenEntity;
+      return accessTokenEntity;
+    } catch (error) {
+      Logger.critical(error);
+      return Promise.reject(error);
+    }
   }
 }

--- a/src/repositories/AuthorizationRepository.ts
+++ b/src/repositories/AuthorizationRepository.ts
@@ -52,7 +52,9 @@ export class AuthorizationRepository implements AuthorizationRepositoryInterface
 
       if (response.status !== 200) {
         Logger.critical(response);
-        throw new InternalServerError();
+        return Promise.reject(
+          new InternalServerError()
+        );
       }
 
       const authorizationIssueResponse: AuthleteResponse.AuthorizationIssueResponse = response.data;
@@ -67,7 +69,9 @@ export class AuthorizationRepository implements AuthorizationRepositoryInterface
           );
         default:
           Logger.critical(authorizationIssueResponse);
-          throw new InternalServerError(authorizationIssueResponse.resultMessage);
+          return Promise.reject(
+            new InternalServerError(authorizationIssueResponse.resultMessage)
+          );
       }
     } catch (error) {
       Logger.critical(error);
@@ -113,7 +117,9 @@ export class AuthorizationRepository implements AuthorizationRepositoryInterface
       const response: AxiosResponse = await axios.post("https://api.authlete.com/api/auth/authorization", requestData, requestConfig);
       if (response.status !== 200) {
         Logger.critical(response);
-        throw new InternalServerError();
+        return Promise.reject(
+          new InternalServerError()
+        );
       }
 
       const authorizationResponse: AuthleteResponse.Authorization = response.data;
@@ -127,10 +133,14 @@ export class AuthorizationRepository implements AuthorizationRepositoryInterface
           );
         case "INTERNAL_SERVER_ERROR":
           Logger.critical(authorizationResponse);
-          throw new InternalServerError(authorizationResponse.resultMessage);
+          return Promise.reject(
+            new InternalServerError(authorizationResponse.resultMessage)
+          );
         default:
           Logger.critical(authorizationResponse);
-          throw new InternalServerError(authorizationResponse.resultMessage);
+          return Promise.reject(
+            new InternalServerError(authorizationResponse.resultMessage)
+          );
       }
     } catch (error) {
       Logger.critical(error);


### PR DESCRIPTION
非同期処理内で意図して発生させた例外は ```return Promise.reject()``` に統一します。

理由としては、元々例外を捕まえる為に try ctach で全体を囲っているので、throwだとctachブロックで囲まれるから意図していない例外とこちらで明示的に発生させた例外とが区別出来なくなる為。