### PR TITLE
DynamoDBClientを利用しているRepositoryクラスをasync, awaitを使った形に変更

### DIFF
--- a/src/repositories/ResourceRepository.ts
+++ b/src/repositories/ResourceRepository.ts
@@ -69,8 +69,8 @@ export class ResourceRepository implements ResourceRepositoryInterface {
    * @param resourceEntity
    * @returns {Promise<ResourceEntity>}
    */
-  save(resourceEntity: ResourceEntity): Promise<ResourceEntity> {
-    return new Promise<ResourceEntity>((resolve: Function, reject: Function) => {
+  async save(resourceEntity: ResourceEntity): Promise<ResourceEntity> {
+    try {
       const resourceCreateParams = {
         id: resourceEntity.id,
         http_method: resourceEntity.httpMethod,
@@ -86,19 +86,15 @@ export class ResourceRepository implements ResourceRepositoryInterface {
         Item: resourceCreateParams
       };
 
-      this.dynamoDbDocumentClient
-        .put(params)
-        .promise()
-        .then(() => {
-          return resolve(resourceEntity);
-        })
-        .catch((error: Error) => {
-          Logger.critical(error);
-          return reject(
-            new InternalServerError(error.message)
-          );
-        });
-    });
+      await this.dynamoDbDocumentClient.put(params).promise();
+
+      return resourceEntity;
+    } catch (error) {
+      Logger.critical(error);
+      return Promise.reject(
+        new InternalServerError(error.message)
+      );
+    }
   }
 
   /**
@@ -107,8 +103,8 @@ export class ResourceRepository implements ResourceRepositoryInterface {
    * @param resourceId
    * @returns {Promise<void>}
    */
-  destroy(resourceId: string): Promise<void> {
-    return new Promise<void>((resolve: Function, reject: Function) => {
+  async destroy(resourceId: string): Promise<void> {
+    try {
       const params = {
         TableName: this.getResourcesTableName(),
         Key: {
@@ -116,17 +112,15 @@ export class ResourceRepository implements ResourceRepositoryInterface {
         }
       };
 
-      this.dynamoDbDocumentClient
-        .delete(params)
-        .promise()
-        .then(() => {
-          return resolve();
-        })
-        .catch((error) => {
-          Logger.critical(error);
-          return reject(error);
-        });
-    });
+      await this.dynamoDbDocumentClient.delete(params).promise();
+
+      return Promise.resolve();
+    } catch (error) {
+      Logger.critical(error);
+      return Promise.reject(
+        new InternalServerError(error.message)
+      );
+    }
   }
 
   /**

--- a/src/repositories/UserRepository.ts
+++ b/src/repositories/UserRepository.ts
@@ -72,8 +72,8 @@ export default class UserRepository implements UserRepositoryInterface {
    * @param userEntity
    * @returns {Promise<UserEntity>}
    */
-  save(userEntity: UserEntity): Promise<UserEntity> {
-    return new Promise<UserEntity>((resolve: Function, reject: Function) => {
+  async save(userEntity: UserEntity): Promise<UserEntity> {
+    try {
       const userCreateParams = {
         id: userEntity.id,
         email: userEntity.email,
@@ -91,19 +91,15 @@ export default class UserRepository implements UserRepositoryInterface {
         Item: userCreateParams
       };
 
-      this.dynamoDbDocumentClient
-        .put(params)
-        .promise()
-        .then(() => {
-          return resolve(userEntity);
-        })
-        .catch((error) => {
-          Logger.critical(error);
-          return reject(
-            new InternalServerError(error.message)
-          );
-        });
-    });
+      await this.dynamoDbDocumentClient.put(params).promise();
+
+      return userEntity;
+    } catch (error) {
+      Logger.critical(error);
+      return Promise.reject(
+        new InternalServerError(error.message)
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
表題の通り。ただしfind系のメソッドはそのままにしてある。

理由はDynamoDbResponseという独自型定義を利用していて、async awaitにすると.get().promise() の返り値にDynamoDB.GetItemOutputしか代入出来なくなり、かえってコーディングがやりにくくなる為。
