### PR TITLE
resolve #177 LambdaのruntimeをNode.js 8.10に変更

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -6,7 +6,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs8.10
   region: ap-northeast-1
   stage: ${env:DEPLOY_STAGE}
   iamRoleStatements:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     // コンパイル後のターゲット（'es3', 'es5', 'es2015', 'es2016', 'es2017'）
     // 何も指定しない場合のデフォルト値は'es3'の模様
-    "target": "es2015",
+    "target": "es2017",
     // SourceMapを出力する
     "sourceMap": true,
     // 出力先のディレクトリ
@@ -28,6 +28,8 @@
     // 暗黙的な undefined を返す事を禁止する
     "noImplicitReturns": true,
     "lib": [
+      "es2015",
+      "es2016",
       "es2017"
     ],
     "types": [


### PR DESCRIPTION
https://github.com/keitakn/aws-serverless-prototype/issues/177

Node.jsを新しく使えるようになった8.10に変更。

TypeScriptのコンパイルオプションもついでに変更。（大分可読性の高いJavaScriptが出力されるようになった）